### PR TITLE
Hook to luajit mm (https://github.com/cloudflare/luajit-mm).

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -452,6 +452,13 @@ LJLIB_O= lib_base.o lib_math.o lib_bit.o lib_string.o lib_table.o \
 	 lib_io.o lib_os.o lib_package.o lib_debug.o lib_jit.o lib_ffi.o
 LJLIB_C= $(LJLIB_O:.o=.c)
 
+ifeq (x64,$(TARGET_LJARCH))
+ifneq (, $(LJMM_DIR))
+CCOPT += -DUSE_LJMM
+LJMM_O := $(LJMM_DIR)/ljmm-combined.o
+endif
+endif
+
 LJCORE_O= lj_gc.o lj_err.o lj_char.o lj_bc.o lj_obj.o \
 	  lj_str.o lj_tab.o lj_func.o lj_udata.o lj_meta.o lj_debug.o \
 	  lj_state.o lj_dispatch.o lj_vmevent.o lj_vmmath.o lj_strscan.o \
@@ -463,7 +470,7 @@ LJCORE_O= lj_gc.o lj_err.o lj_char.o lj_bc.o lj_obj.o \
 	  lj_ctype.o lj_cdata.o lj_cconv.o lj_ccall.o lj_ccallback.o \
 	  lj_carith.o lj_clib.o lj_cparse.o \
 	  lj_lib.o lj_alloc.o lib_aux.o \
-	  $(LJLIB_O) lib_init.o
+	  $(LJLIB_O) $(LJMM_O) lib_init.o
 
 LJVMCORE_O= $(LJVM_O) $(LJCORE_O)
 LJVMCORE_DYNO= $(LJVMCORE_O:.o=_dyn.o)
@@ -567,6 +574,16 @@ E= @echo
 ##############################################################################
 
 default all:	$(TARGET_T)
+
+ifeq (x64,$(TARGET_LJARCH))
+ifneq (, $(LJMM_DIR))
+$(LJMM_DIR)/ljmm-combined.o :
+	$(MAKE) CC=$(CC) OPT_FLAGS="$(CCOPT)" -C $(LJMM_DIR)
+
+$(TARGET_T) : $(LJMM_DIR)/ljmm-combined.o
+
+endif
+endif
 
 amalg:
 	@grep "^[+|]" ljamalg.c

--- a/src/lj_alloc.c
+++ b/src/lj_alloc.c
@@ -168,6 +168,15 @@ static LJ_AINLINE int CALL_MUNMAP(void *ptr, size_t size)
 #include <errno.h>
 #include <sys/mman.h>
 
+#ifdef USE_LJMM
+	void *ljmm_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t);
+	int ljmm_munmap(void *addr, size_t length);
+	void *ljmm_mremap(void *old_address, size_t old_size, size_t new_size, int flags, ...);
+	#define mmap ljmm_mmap
+	#define munmp ljmm_munmap
+	#define mremap ljmm_mremap
+#endif
+
 #define MMAP_PROT		(PROT_READ|PROT_WRITE)
 #if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
 #define MAP_ANONYMOUS		MAP_ANON


### PR DESCRIPTION
To enable it, invoke make-utility with LJMM_DIR=/the/path/to/luajit-mm/dir.

Currently it works only for Linux/x86-64 box. If the target is for
32-bit platform (including i386 family), ljmm is automatically disabled
regardless the LJMM_DIR is specified or not. It might works for
Other-Unix/x86-64. but I don't know for sure at this moment.
