### PR TITLE
feature: add an option `L` to show opcode with lineinfo.

### DIFF
--- a/src/jit/bc.lua
+++ b/src/jit/bc.lua
@@ -63,15 +63,21 @@ local function ctlsub(c)
 end
 
 -- Return one bytecode line.
-local function bcline(func, pc, prefix)
-  local ins, m = funcbc(func, pc)
+local function bcline(func, pc, prefix, lineinfo)
+  local ins, m, l = funcbc(func, pc, lineinfo and 1 or 0)
   if not ins then return end
   local ma, mb, mc = band(m, 7), band(m, 15*8), band(m, 15*128)
   local a = band(shr(ins, 8), 0xff)
   local oidx = 6*band(ins, 0xff)
   local op = sub(bcnames, oidx+1, oidx+6)
-  local s = format("%04d %s %-6s %3s ",
-    pc, prefix or "  ", op, ma == 0 and "" or a)
+  local s
+  if lineinfo then
+    s = format("%04d %7s %s %-6s %3s ",
+      pc, "["..l.."]", prefix or "  ", op, ma == 0 and "" or a)
+  else
+    s = format("%04d %s %-6s %3s ",
+      pc, prefix or "  ", op, ma == 0 and "" or a)
+  end
   local d = shr(ins, 16)
   if mc == 13*128 then -- BCMjump
     return format("%s=> %04d\n", s, pc+d-0x7fff)
@@ -124,20 +130,20 @@ local function bctargets(func)
 end
 
 -- Dump bytecode instructions of a function.
-local function bcdump(func, out, all)
+local function bcdump(func, out, all, lineinfo)
   if not out then out = stdout end
   local fi = funcinfo(func)
   if all and fi.children then
     for n=-1,-1000000000,-1 do
       local k = funck(func, n)
       if not k then break end
-      if type(k) == "proto" then bcdump(k, out, true) end
+      if type(k) == "proto" then bcdump(k, out, true, lineinfo) end
     end
   end
   out:write(format("-- BYTECODE -- %s-%d\n", fi.loc, fi.lastlinedefined))
   local target = bctargets(func)
   for pc=1,1000000000 do
-    local s = bcline(func, pc, target[pc] and "=>")
+    local s = bcline(func, pc, target[pc] and "=>", lineinfo)
     if not s then break end
     out:write(s)
   end

--- a/src/jit/bcsave.lua
+++ b/src/jit/bcsave.lua
@@ -621,7 +621,7 @@ local function docmd(...)
 	  list = true
     elseif opt == "L" then
 	  list = true
-      lineinfo = true
+	  lineinfo = true
 	elseif opt == "s" then
 	  ctx.strip = true
 	elseif opt == "g" then

--- a/src/jit/bcsave.lua
+++ b/src/jit/bcsave.lua
@@ -23,6 +23,7 @@ local function usage()
   io.stderr:write[[
 Save LuaJIT bytecode: luajit -b[options] input output
   -l        Only list bytecode.
+  -L        Only list bytecode with lineinfo.
   -s        Strip debug info (default).
   -g        Keep debug info.
   -n name   Set module name (default: auto-detect from input name).
@@ -575,9 +576,9 @@ end
 
 ------------------------------------------------------------------------------
 
-local function bclist(input, output)
+local function bclist(input, output, lineinfo)
   local f = readfile(input)
-  require("jit.bc").dump(f, savefile(output, "w"), true)
+  require("jit.bc").dump(f, savefile(output, "w"), true, lineinfo)
 end
 
 local function bcsave(ctx, input, output)
@@ -604,6 +605,7 @@ local function docmd(...)
   local arg = {...}
   local n = 1
   local list = false
+  local lineinfo = false
   local ctx = {
     strip = true, arch = jit.arch, os = string.lower(jit.os),
     type = false, modname = false,
@@ -617,6 +619,9 @@ local function docmd(...)
 	local opt = string.sub(a, m, m)
 	if opt == "l" then
 	  list = true
+    elseif opt == "L" then
+	  list = true
+      lineinfo = true
 	elseif opt == "s" then
 	  ctx.strip = true
 	elseif opt == "g" then
@@ -645,7 +650,7 @@ local function docmd(...)
   end
   if list then
     if #arg == 0 or #arg > 2 then usage() end
-    bclist(arg[1], arg[2] or "-")
+    bclist(arg[1], arg[2] or "-", lineinfo)
   else
     if #arg ~= 2 then usage() end
     bcsave(ctx, arg[1], arg[2])

--- a/src/lib_jit.c
+++ b/src/lib_jit.c
@@ -223,6 +223,7 @@ LJLIB_CF(jit_util_funcbc)
 {
   GCproto *pt = check_Lproto(L, 0);
   BCPos pc = (BCPos)lj_lib_checkint(L, 2);
+  int lineinfo = lj_lib_optint(L, 3, 0);
   if (pc < pt->sizebc) {
     BCIns ins = proto_bc(pt)[pc];
     BCOp op = bc_op(ins);
@@ -230,6 +231,11 @@ LJLIB_CF(jit_util_funcbc)
     setintV(L->top, ins);
     setintV(L->top+1, lj_bc_mode[op]);
     L->top += 2;
+    if (lineinfo) {
+      setintV(L->top, lj_debug_line(pt, pc));
+      L->top += 1;
+      return 3;
+    }
     return 2;
   }
   return 0;


### PR DESCRIPTION
so that we can use `luajit -bL code.lua | grep -E 'G[GS]ET'` in lua-releng.