### PR TITLE
Remove hard-coded hash-value of string.

### DIFF
--- a/src/lj_str.c
+++ b/src/lj_str.c
@@ -68,6 +68,18 @@ static LJ_AINLINE int str_fastcmp(const char *a, const char *b, MSize len)
   return 0;
 }
 
+int32_t LJ_FASTCALL lj_str_equ(GCstr *a, const char *b, MSize b_len)
+{
+  if (a->len != b_len) {
+    return 1;
+  }
+
+  /* Do *NOT* transpose the 1st and 2nd argument, as the 2nd argument must be
+   * aligned at least at 4-byte boundary.
+   */
+  return str_fastcmp(b, strdata(a), b_len);
+}
+
 /* Find fixed string p inside string s. */
 const char *lj_str_find(const char *s, const char *p, MSize slen, MSize plen)
 {

--- a/src/lj_str.h
+++ b/src/lj_str.h
@@ -12,6 +12,8 @@
 
 /* String helpers. */
 LJ_FUNC int32_t LJ_FASTCALL lj_str_cmp(GCstr *a, GCstr *b);
+LJ_FUNC int32_t LJ_FASTCALL lj_str_equ(GCstr *a, const char *b, MSize b_len);
+
 LJ_FUNC const char *lj_str_find(const char *s, const char *f,
 				MSize slen, MSize flen);
 LJ_FUNC int lj_str_haspattern(GCstr *s);

--- a/src/x64/test/Makefile
+++ b/src/x64/test/Makefile
@@ -24,6 +24,7 @@ CXXFLAGS := -O3 -MD -g -msse4.2 -Wall -I../src -I../../../src
 test: $(TEST_PROGRAM)
 	@echo "some unit test"
 	$(VALGRIND) ./$(TEST_PROGRAM)
+	./unit_test.sh
 
 	@echo "smoke test"
 	../../luajit test_str_comp.lua

--- a/src/x64/test/unit/ffi/test_abi.lua
+++ b/src/x64/test/unit/ffi/test_abi.lua
@@ -1,0 +1,10 @@
+local ffi = require "ffi"
+
+-- TODO: test "gc64" and "win" parameters
+assert((ffi.abi("32bit") or ffi.abi("64bit"))
+        and ffi.abi("le")
+        and not ffi.abi("be")
+        and ffi.abi("fpu")
+        and not ffi.abi("softfp")
+        and ffi.abi("hardfp")
+        and not ffi.abi("eabi"))

--- a/src/x64/test/unit/ffi/test_line_directive.lua
+++ b/src/x64/test/unit/ffi/test_line_directive.lua
@@ -1,0 +1,15 @@
+local x = [=[
+local ffi = require "ffi"
+
+ffi.cdef [[
+    #line 100
+    typedef Int xxx
+]]
+]=]
+
+local function foo()
+    loadstring(x)()
+end
+
+local r, e = pcall(foo)
+assert(string.find(e, "declaration specifier expected near 'Int' at line 100") ~= nil)

--- a/src/x64/test/unit/ffi/test_pragma_pack_pushpop.lua
+++ b/src/x64/test/unit/ffi/test_pragma_pack_pushpop.lua
@@ -1,0 +1,12 @@
+local ffi = require "ffi"
+
+ffi.cdef[[
+#pragma pack(push, 1)
+typedef struct {
+    char x;
+    double y;
+} foo;
+#pragma pack(pop)
+]]
+
+assert(ffi.sizeof("foo") == 9)

--- a/src/x64/test/unit/ffi/test_var_attribute.lua
+++ b/src/x64/test/unit/ffi/test_var_attribute.lua
@@ -1,0 +1,13 @@
+local ffi = require "ffi"
+
+ffi.cdef[[
+typedef struct { int a; char b; } __attribute__((packed)) myty1;
+typedef struct { int a; char b; } __attribute__((aligned(16))) myty2;
+typedef int __attribute__ ((vector_size (32))) myty3;
+typedef int __attribute__ ((mode(DI))) myty4;
+]]
+
+assert(ffi.sizeof("myty1") == 5 and
+       ffi.alignof("myty2") == 16 and
+       ffi.sizeof("myty3") == 32 and
+       ffi.sizeof("myty4") == 8)

--- a/src/x64/test/unit_test.sh
+++ b/src/x64/test/unit_test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+DIR=$(cd $(dirname $0); pwd)
+cd $DIR
+
+LUAJIT=$DIR/../../luajit
+HASERR=0
+
+find $DIR/unit -name "*.lua" -print | while read x; do
+    $LUAJIT $x >/dev/null 2>/dev/null
+    if [ $? -eq 0 ]; then
+        echo "$x ok"
+    else
+        HASERR=1
+        echo "$x failed"
+    fi
+done
+
+if [ $HASERR -eq 0 ]; then
+    exit 0
+fi
+
+exit 1


### PR DESCRIPTION
It would otherwise be impossible to change string-hash algorithm.
This change fixes https://github.com/openresty/luajit2/issues/10

The test does not cover following situation:
    o. attribute used by MSVC
    o. attribute used only on x86 system (not familar with those attributes)