### PR TITLE
bugfix: resume read system call upon EINTR during file readall.

### DIFF
--- a/src/lib_io.c
+++ b/src/lib_io.c
@@ -164,9 +164,14 @@ static void io_file_readall(lua_State *L, FILE *fp)
   MSize m, n;
   for (m = LUAL_BUFFERSIZE, n = 0; ; m += m) {
     char *buf = lj_buf_tmp(L, m);
-    n += (MSize)fread(buf+n, 1, m-n, fp);
-    if (n != m) {
-      setstrV(L, L->top++, lj_str_new(L, buf, (size_t)n));
+    for (;;) {
+      n += (MSize)fread(buf+n, 1, m-n, fp);
+      if (n == m) break;
+      if (ferror(fp)) {
+        if (errno == EINTR) { clearerr(fp); continue; }
+      } else {
+        setstrV(L, L->top++, lj_str_new(L, buf, (size_t)n));
+      }
       lj_gc_check(L);
       return;
     }


### PR DESCRIPTION
Patch proposed in #15, ported to its own PR. Test case located at https://github.com/openresty/resty-cli/pull/37.