### PR TITLE
Revert I/O retry on EINTR patch

### DIFF
--- a/src/lib_io.c
+++ b/src/lib_io.c
@@ -164,14 +164,9 @@ static void io_file_readall(lua_State *L, FILE *fp)
   MSize m, n;
   for (m = LUAL_BUFFERSIZE, n = 0; ; m += m) {
     char *buf = lj_buf_tmp(L, m);
-    for (;;) {
-      n += (MSize)fread(buf+n, 1, m-n, fp);
-      if (n == m) break;
-      if (ferror(fp)) {
-        if (errno == EINTR) { clearerr(fp); continue; }
-      } else {
-        setstrV(L, L->top++, lj_str_new(L, buf, (size_t)n));
-      }
+    n += (MSize)fread(buf+n, 1, m-n, fp);
+    if (n != m) {
+      setstrV(L, L->top++, lj_str_new(L, buf, (size_t)n));
       lj_gc_check(L);
       return;
     }


### PR DESCRIPTION
This is one of 4 PRs to properly handle `EINTR` errors in resty-cli (and/or OpenResty if desired by the user).

- (this PR) Revert the "retry on EINTR" patch from openresty/luajit2#16
- https://github.com/openresty/lua-nginx-module/pull/1296 Implement an FFI API to enable `SA_RESTART` on signal handlers
- https://github.com/openresty/lua-resty-core/pull/183 Implement the Lua `sig_restart()` API
- https://github.com/openresty/resty-cli/pull/41 Enable the `SA_RESTART` flag on interrupting signals

If all PRs are merged:
- we get rid of the "retry on EINTR" LuaJIT patch which was refused upstream
- resty-cli users can safely use APIs like `io.popen()` https://github.com/openresty/resty-cli/issues/35
- OpenResty users can toggle this behaviour on/off as desired (off by default)