### PR TITLE
bugfix: fixed a segfault when unsinking 64-bit pointers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,20 +30,20 @@ env:
   - JOBS=3
   - LUAJIT_PREFIX=/opt/luajit21
   - LUAJIT_SYSM_PREFIX=/opt/luajit21-sysm
+  - LUAJIT_COMMON_XCFLAGS="-DLUA_USE_APICHECK -DLUA_USE_ASSERT -DLUAJIT_NUMMODE=2 -msse4.2 -O1"
+  matrix:
+  - LUAJIT_XCFLAGS="$LUAJIT_COMMON_XCFLAGS"
+  - LUAJIT_XCFLAGS="-DLUAJIT_ENABLE_LUA52COMPAT $LUAJIT_COMMON_XCFLAGS" LUA52=1
+  - LUAJIT_XCFLAGS="-DLUAJIT_USE_VALGRIND -DLUAJIT_USE_SYSMALLOC -DLUAJIT_ENABLE_LUA52COMPAT $LUAJIT_COMMON_XCFLAGS" LUA52=1 FLAGS=-v
+  - LUAJIT_XCFLAGS="-DLUAJIT_USE_GC64 -DLUAJIT_ENABLE_LUA52COMPAT $LUAJIT_COMMON_XCFLAGS" LUA52=1
 
 install:
   - git clone https://github.com/openresty/luajit2-test-suite.git ../luajit2-test-suite
 
 script:
   - valgrind --version
-  - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_PREFIX CC=$CC XCFLAGS='-DLUA_USE_APICHECK -DLUA_USE_ASSERT -DLUAJIT_NUMMODE=2 -msse4.2 -O1' > build.log 2>&1 || (cat build.log && exit 1)
+  - cd ../luajit2
+  - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_PREFIX CC=$CC XCFLAGS="$LUAJIT_XCFLAGS" > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make install PREFIX=$LUAJIT_PREFIX > build.log 2>&1 || (cat build.log && exit 1)
   - cd ../luajit2-test-suite
-  - ./run-tests -j $JOBS $LUAJIT_PREFIX
-  - echo "starting valgrind mod"
-  - cd -
-  - make clean
-  - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_SYSM_PREFIX CC=$CC XCFLAGS='-DLUAJIT_NUMMODE=2 -DLUA_USE_APICHECK -DLUA_USE_ASSERT -DLUAJIT_USE_VALGRIND -DLUAJIT_USE_SYSMALLOC -O1 -msse4.2' > build.log 2>&1 || (cat build.log && exit 1)
-  - sudo make install PREFIX=$LUAJIT_SYSM_PREFIX > build.log 2>&1 || (cat build.log && exit 1)
-  - cd ../luajit2-test-suite
-  - ./run-tests -j $JOBS -v $LUAJIT_SYSM_PREFIX
+  - ./run-tests -j $JOBS $FLAGS $LUAJIT_PREFIX

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
   - LUAJIT_XCFLAGS="-DLUAJIT_USE_GC64 -DLUAJIT_ENABLE_LUA52COMPAT $LUAJIT_COMMON_XCFLAGS" LUA52=1
 
 install:
-  - git clone https://github.com/openresty/luajit2-test-suite.git ../luajit2-test-suite
+  - git clone -b tests/unsink-64-ptr https://github.com/thibaultcha/luajit2-test-suite.git ../luajit2-test-suite
 
 script:
   - valgrind --version

--- a/src/lj_ir.h
+++ b/src/lj_ir.h
@@ -563,6 +563,11 @@ typedef union IRIns {
   TValue tv;		/* TValue constant (overlaps entire slot). */
 } IRIns;
 
+#define ir_isk64(ir) ((ir)->o == IR_KNUM || (ir)->o == IR_KINT64 || \
+                      (LJ_GC64 && \
+                       ((ir)->o == IR_KGC || \
+                       (ir)->o == IR_KPTR || (ir)->o == IR_KKPTR)))
+
 #define ir_kgc(ir)	check_exp((ir)->o == IR_KGC, gcref((ir)[LJ_GC64].gcr))
 #define ir_kstr(ir)	(gco2str(ir_kgc((ir))))
 #define ir_ktab(ir)	(gco2tab(ir_kgc((ir))))
@@ -570,12 +575,7 @@ typedef union IRIns {
 #define ir_kcdata(ir)	(gco2cd(ir_kgc((ir))))
 #define ir_knum(ir)	check_exp((ir)->o == IR_KNUM, &(ir)[1].tv)
 #define ir_kint64(ir)	check_exp((ir)->o == IR_KINT64, &(ir)[1].tv)
-#define ir_k64(ir) \
-  check_exp((ir)->o == IR_KNUM || (ir)->o == IR_KINT64 || \
-	    (LJ_GC64 && \
-	     ((ir)->o == IR_KGC || \
-	      (ir)->o == IR_KPTR || (ir)->o == IR_KKPTR)), \
-	    &(ir)[1].tv)
+#define ir_k64(ir)	check_exp(ir_isk64(ir), &(ir)[1].tv)
 #define ir_kptr(ir) \
   check_exp((ir)->o == IR_KPTR || (ir)->o == IR_KKPTR, \
     mref((ir)[LJ_GC64].ptr, void))

--- a/src/lj_snap.c
+++ b/src/lj_snap.c
@@ -688,7 +688,7 @@ static void snap_restoredata(GCtrace *T, ExitState *ex,
   int32_t *src;
   uint64_t tmp;
   if (irref_isk(ref)) {
-    if (ir->o == IR_KNUM || ir->o == IR_KINT64) {
+    if (ir_isk64(ir)) {
       src = (int32_t *)&ir[1];
     } else if (sz == 8) {
       tmp = (uint64_t)(uint32_t)ir->i;


### PR DESCRIPTION
The unsinking code was not using the correct layout for GC64 IR constants (value in adjacent slot) for this case. This patch is a derivative of raptorjit/raptorjit#246 ported for LuaJIT itself. Fixed after an intense debugging session with @lukego.

Also included in this PR: a matrix of XCFLAGS on Travis-CI, to which we added non Lua 5.2 and GC64 modes.

Sister PR with test: https://github.com/openresty/luajit2-test-suite/pull/6

Fixes the issue initially reported at: https://github.com/openresty/lua-resty-core/issues/232