### PR TITLE
Fix os.date() for timezone change awareness

### DIFF
--- a/src/lib_os.c
+++ b/src/lib_os.c
@@ -185,6 +185,7 @@ LJLIB_CF(os_date)
 #endif
   } else {
 #if LJ_TARGET_POSIX
+    tzset();
     stm = localtime_r(&t, &rtm);
 #else
     stm = localtime(&t);


### PR DESCRIPTION
On POSIX target, system timezone change are not taken into account.
To reproduce,
1. call os.date()
2. change your timezone
3. call os.date() within the same luajit instance

On POSIX target, os.date use localtime_r to retrieve time.
On other target, the function localtime is used. But there is a behaviour
diference between these two function. localtime acts as if it called tzset
which localtime_r don't.

To fix the issue tzset is called before localtime_r.