### PR TITLE
thread.exdata: Build recff_thread_exdata only for LJ_HASFFI

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ This Lua API can be JIT compiled.
 
 ### thread.exdata
 
-We implemented the new Lua and C API functions for thread exdata.
+We implemented the new Lua and C API functions for thread exdata to allow users
+to embed user data into a thread. This feature needs LuaJIT FFI and hence is
+not available when built with `-DLUAJIT_DISABLE_FFI`.
 
 The Lua API can be used like below:
 

--- a/src/lj_ffrecord.c
+++ b/src/lj_ffrecord.c
@@ -1149,6 +1149,7 @@ static void LJ_FASTCALL recff_table_isempty(jit_State *J, RecordFFData *rd)
 
 /* -- thread library fast functions ------------------------------------------ */
 
+#if LJ_HASFFI
 void LJ_FASTCALL recff_thread_exdata(jit_State *J, RecordFFData *rd)
 {
   TRef tr = J->base[0];
@@ -1161,6 +1162,7 @@ void LJ_FASTCALL recff_thread_exdata(jit_State *J, RecordFFData *rd)
   }
   recff_nyiu(J, rd);  /* this case is too rare to be interesting */
 }
+#endif
 
 /* -- I/O library fast functions ------------------------------------------ */
 


### PR DESCRIPTION
This fixes builds with -DLUAJIT_DISABLE_FFI.