### PR TITLE
Dynamic detection of SSE42

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -507,10 +507,16 @@ LJCORE_O= lj_assert.o lj_gc.o lj_err.o lj_char.o lj_bc.o lj_obj.o lj_buf.o \
 	  lj_ctype.o lj_cdata.o lj_cconv.o lj_ccall.o lj_ccallback.o \
 	  lj_carith.o lj_clib.o lj_cparse.o \
 	  lj_lib.o lj_alloc.o lib_aux.o \
-	  $(LJLIB_O) lib_init.o
+	  $(LJLIB_O) lib_init.o lj_str_hash.o
+
+ifeq (x64,$(TARGET_LJARCH))
+  lj_str_hash-CFLAGS = -msse4.2
+endif
+
+F_CFLAGS = $($(patsubst %.c,%-CFLAGS,$<))
 
 LJVMCORE_O= $(LJVM_O) $(LJCORE_O)
-LJVMCORE_DYNO= $(LJVMCORE_O:.o=_dyn.o)
+LJVMCORE_DYNO= $(LJVMCORE_O:.o=_dyn.o) lj_init_dyn.o
 
 LIB_VMDEF= jit/vmdef.lua
 LIB_VMDEFP= $(LIB_VMDEF)
@@ -532,7 +538,7 @@ ALL_RM= $(ALL_T) $(ALL_GEN) *.o host/*.o $(WIN_RM)
 ##############################################################################
 
 # Mixed mode defaults.
-TARGET_O= $(LUAJIT_A)
+TARGET_O= lj_init.o $(LUAJIT_A)
 TARGET_T= $(LUAJIT_T) $(LUAJIT_SO)
 TARGET_DEP= $(LIB_VMDEF) $(LUAJIT_SO)
 
@@ -614,7 +620,7 @@ E= @echo
 default all:	$(TARGET_T)
 
 amalg:
-	$(MAKE) all "LJCORE_O=ljamalg.o"
+	$(MAKE) all "LJCORE_O=ljamalg.o lj_str_hash.o"
 
 clean:
 	$(HOST_RM) $(ALL_RM)
@@ -691,8 +697,8 @@ lj_folddef.h: $(BUILDVM_T) lj_opt_fold.c
 
 %.o: %.c
 	$(E) "CC        $@"
-	$(Q)$(TARGET_DYNCC) $(TARGET_ACFLAGS) -c -o $(@:.o=_dyn.o) $<
-	$(Q)$(TARGET_CC) $(TARGET_ACFLAGS) -c -o $@ $<
+	$(Q)$(TARGET_DYNCC) $(TARGET_ACFLAGS) $(F_CFLAGS) -c -o $(@:.o=_dyn.o) $<
+	$(Q)$(TARGET_CC) $(TARGET_ACFLAGS) $(F_CFLAGS) -c -o $@ $<
 
 %.o: %.S
 	$(E) "ASM       $@"

--- a/src/lj_arch.h
+++ b/src/lj_arch.h
@@ -209,6 +209,10 @@
 #define LJ_TARGET_GC64		1
 #endif
 
+#ifdef __GNUC__
+#define LJ_HAS_OPTIMISED_HASH  1
+#endif
+
 #elif LUAJIT_TARGET == LUAJIT_ARCH_ARM
 
 #define LJ_ARCH_NAME		"arm"

--- a/src/lj_init.c
+++ b/src/lj_init.c
@@ -1,0 +1,69 @@
+#include <stdint.h>
+#include "lj_arch.h"
+#include "lj_jit.h"
+#include "lj_vm.h"
+#include "lj_str.h"
+
+#if LJ_TARGET_ARM && LJ_TARGET_LINUX
+#include <sys/utsname.h>
+#endif
+
+#ifdef _MSC_VER
+/*
+** Append a function pointer to the static constructor table executed by
+** the C runtime.
+** Based on https://stackoverflow.com/questions/1113409/attribute-constructor-equivalent-in-vc
+** see also https://docs.microsoft.com/en-us/cpp/c-runtime-library/crt-initialization.
+*/
+#pragma section(".CRT$XCU",read)
+#define LJ_INITIALIZER2_(f,p) \
+        static void f(void); \
+        __declspec(allocate(".CRT$XCU")) void (*f##_)(void) = f; \
+        __pragma(comment(linker,"/include:" p #f "_")) \
+        static void f(void)
+#ifdef _WIN64
+#define LJ_INITIALIZER(f) LJ_INITIALIZER2_(f,"")
+#else
+#define LJ_INITIALIZER(f) LJ_INITIALIZER2_(f,"_")
+#endif
+
+#else
+#define LJ_INITIALIZER(f) static void __attribute__((constructor)) f(void)
+#endif
+
+
+#ifdef LJ_HAS_OPTIMISED_HASH
+static void str_hash_init(uint32_t flags)
+{
+  if (flags & JIT_F_SSE4_2)
+    str_hash_init_sse42 ();
+}
+
+/* CPU detection for interpreter features such as string hash function
+   selection.  We choose to cherry-pick from lj_cpudetect and not have a single
+   initializer to make sure that merges with LuaJIT/LuaJIT remain
+   convenient. */
+LJ_INITIALIZER(lj_init_cpuflags)
+{
+  uint32_t flags = 0;
+#if LJ_TARGET_X86ORX64
+
+  uint32_t vendor[4];
+  uint32_t features[4];
+  if (lj_vm_cpuid(0, vendor) && lj_vm_cpuid(1, features)) {
+    flags |= ((features[2] >> 0)&1) * JIT_F_SSE3;
+    flags |= ((features[2] >> 19)&1) * JIT_F_SSE4_1;
+    flags |= ((features[2] >> 20)&1) * JIT_F_SSE4_2;
+    if (vendor[0] >= 7) {
+      uint32_t xfeatures[4];
+      lj_vm_cpuid(7, xfeatures);
+      flags |= ((xfeatures[1] >> 8)&1) * JIT_F_BMI2;
+    }
+  }
+
+#endif
+
+  /* The reason why we initialized early: select our string hash functions.  */
+  str_hash_init (flags);
+}
+#endif

--- a/src/lj_jit.h
+++ b/src/lj_jit.h
@@ -22,6 +22,7 @@
 #define JIT_F_SSE3		(JIT_F_CPU << 0)
 #define JIT_F_SSE4_1		(JIT_F_CPU << 1)
 #define JIT_F_BMI2		(JIT_F_CPU << 2)
+#define JIT_F_SSE4_2		(JIT_F_CPU << 3)
 
 
 #define JIT_F_CPUSTRING		"\4SSE3\6SSE4.1\4BMI2"

--- a/src/lj_str.h
+++ b/src/lj_str.h
@@ -28,4 +28,16 @@ LJ_FUNC void LJ_FASTCALL lj_str_init(lua_State *L);
 #define lj_str_newlit(L, s)	(lj_str_new(L, "" s, sizeof(s)-1))
 #define lj_str_size(len)	(sizeof(GCstr) + (((len)+4) & ~(MSize)3))
 
+#ifdef LJ_HAS_OPTIMISED_HASH
+typedef StrHash (*str_sparse_hashfn) (uint64_t, const char *, MSize);
+extern str_sparse_hashfn hash_sparse;
+
+#if LUAJIT_SECURITY_STRHASH
+typedef StrHash (*str_dense_hashfn) (uint64_t, StrHash, const char *, MSize);
+extern str_dense_hashfn hash_dense;
+#endif
+
+extern void str_hash_init_sse42 (void);
+#endif
+
 #endif

--- a/src/ljamalg.c
+++ b/src/ljamalg.c
@@ -86,4 +86,3 @@
 #include "lib_jit.c"
 #include "lib_ffi.c"
 #include "lib_init.c"
-

--- a/src/x64/test/test.cpp
+++ b/src/x64/test/test.cpp
@@ -4,9 +4,13 @@
 #include <map>
 #define LUAJIT_SECURITY_STRHASH 1
 #include "test_util.hpp"
-#include "lj_str_hash_x64.h"
+#include "../../lj_str.h"
+str_sparse_hashfn hash_sparse;
+str_dense_hashfn hash_dense;
+#include "../../lj_str_hash.c"
 
 using namespace std;
+
 
 static bool
 smoke_test()
@@ -24,9 +28,9 @@ smoke_test()
                      255, 256, 257};
   for (unsigned i = 0; i < sizeof(lens)/sizeof(lens[0]); i++) {
     string s(buf, lens[i]);
-    uint32_t h = hash_sparse(rand(), s.c_str(), lens[i]);
+    uint32_t h = hash_sparse_sse42(rand(), s.c_str(), lens[i]);
     test_printf("%d", h);
-    test_printf("%d", hash_dense(rand(), h, s.c_str(), lens[i]));
+    test_printf("%d", hash_dense_sse42(rand(), h, s.c_str(), lens[i]));
   }
 
   return true;


### PR DESCRIPTION
This series of patches moves the CRC32 based `lj_str_hash` implementation into the main sources and builds it with `-msse42`.  We also move the CPU feature detection into a DSO constructor and use it to patch in the optimised lj_str_hash if we are running on a CPU with SSE4.2, making the binaries more portable across x86 platforms.

This should obsolete #20 and also give a good framework to implement #21 making it a simple matter of adding the conditional compilation (and feature check) for crc32 and defining the right crc32 macros.