### PR TITLE
Remove the duplicate header file lj_iropt.h from lj_asm.c

### DIFF
--- a/src/lj_asm.c
+++ b/src/lj_asm.c
@@ -22,7 +22,6 @@
 #include "lj_ircall.h"
 #include "lj_iropt.h"
 #include "lj_mcode.h"
-#include "lj_iropt.h"
 #include "lj_trace.h"
 #include "lj_snap.h"
 #include "lj_asm.h"


### PR DESCRIPTION
Keep the code clean.