### PR TITLE
Fix BC_NOT on s390x

### DIFF
--- a/src/vm_s390x.dasc
+++ b/src/vm_s390x.dasc
@@ -2540,8 +2540,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  lg RB, 0(RD, BASE)
     |  srag RB, RB, 47
     |  load_false RC
-    |  cghi RB, LJ_TTRUE
-    |  je >1
+    |  clfi RB, LJ_TISTRUECOND
+    |  jl >1
     |  load_true RC
     |1:
     |  stg RC, 0(RA, BASE)


### PR DESCRIPTION
The code checks for "== true", but it should rather check for "!= nil &&
!= false".

Signed-off-by: Ilya Leoshkevich <iii@linux.ibm.com>