### PR TITLE
alloc/ARM64:When the table is expanded, a 48-bit address may be used.

### DIFF
--- a/src/lj_alloc.c
+++ b/src/lj_alloc.c
@@ -379,7 +379,7 @@ static void *CALL_MREMAP_(void *ptr, size_t osz, size_t nsz, int flags)
 #define CALL_MREMAP(addr, osz, nsz, mv) CALL_MREMAP_((addr), (osz), (nsz), (mv))
 #define CALL_MREMAP_NOMOVE	0
 #define CALL_MREMAP_MAYMOVE	1
-#if LJ_64 && !LJ_GC64
+#if LJ_TARGET_ARM64 || (LJ_64 && !LJ_GC64)
 #define CALL_MREMAP_MV		CALL_MREMAP_NOMOVE
 #else
 #define CALL_MREMAP_MV		CALL_MREMAP_MAYMOVE


### PR DESCRIPTION
alloc/ARM64:When the table is expanded, a 48-bit address may be used，and the process will abort.
The function call relationship is as follows:
lj_mem_realloc()->lj_alloc_f()->lj_alloc_realloc()->direct_resize()->CALL_MREMAP_()
and This line of code("lua_assert(checkptrGC(p));") fails to assert