### PR TITLE
Move luajit-specific elements to the end of state structs

### DIFF
--- a/src/lj_jit.h
+++ b/src/lj_jit.h
@@ -472,8 +472,6 @@ typedef struct jit_State {
 
   HotPenalty penalty[PENALTY_SLOTS];  /* Penalty slots. */
   uint32_t penaltyslot;	/* Round-robin index into penalty slots. */
-  PRNGState prng;	/* PRNG state for the JIT compiler, defaults to prng in
-			   global_State. */
 
 #ifdef LUAJIT_ENABLE_TABLE_BUMP
   RBCHashEntry rbchash[RBCHASH_SLOTS];  /* Reverse bytecode map. */
@@ -505,6 +503,8 @@ typedef struct jit_State {
   BCLine prev_line;	/* Previous line. */
   int prof_mode;	/* Profiling mode: 0, 'f', 'l'. */
 #endif
+  PRNGState prng;	/* PRNG state for the JIT compiler, defaults to prng in
+			   global_State. */
 } jit_State;
 
 #ifdef LUA_USE_ASSERT


### PR DESCRIPTION
Putting prng and saved_jit_state in the middle of the struct messed with alignments on
Armv7.  Avoid the problem by moving the luajit2-specific elements to the end.

Fixes #106.  ~It leaves just one new test failure introduced by the merge, which I will look at next.~