### PR TITLE
bugfix: fixed compatibility regression with MinGW gcc

### DIFF
--- a/src/x64/src/lj_str_hash_x64.h
+++ b/src/x64/src/lj_str_hash_x64.h
@@ -21,6 +21,11 @@
 #undef LJ_AINLINE
 #define LJ_AINLINE
 
+#ifdef __MINGW32__
+#define random()  ((long) rand())
+#define srandom(seed)  srand(seed)
+#endif
+
 static const uint64_t* cast_uint64p(const char* str)
 {
   return (const uint64_t*)(void*)str;


### PR DESCRIPTION
This reverts the reversion that was done to merge with LuaJIT/LuaJIT.

Fixes #111.