### PR TITLE
Change: Resolve compilation error in ppc

### DIFF
--- a/src/lj_ccallback.c
+++ b/src/lj_ccallback.c
@@ -21,6 +21,10 @@
 #include "lj_trace.h"
 #include "lj_vm.h"
 
+#if LJ_ARCH_PPC_ELFV2
+#include "lualib.h"
+#endif
+
 /* -- Target-specific handling of callback slots -------------------------- */
 
 #define CALLBACK_MCODE_SIZE	(LJ_PAGESIZE * LJ_NUM_CBPAGE)


### PR DESCRIPTION
Compilation error faced:
libluajit.a(lj_ccallback.o): In function `callback_mcode_init':
**/compile/luajit2/src/lj_ccallback.c:229: undefined reference to `lua_assert'**
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile:734: luajit] Error 1
make[1]: Leaving directory '/compile/luajit2/src'
make: *** [Makefile:113: default] Error 2

Solution:
Include "lualib.h" file in lj_ccallback.c