### PR TITLE
This PR fixes build issue on s390x introduced with commit 394fb6267ac…

### DIFF
--- a/src/vm_s390x.dasc
+++ b/src/vm_s390x.dasc
@@ -1793,7 +1793,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  stg BASE, L:RB->base
   |   lg RC, SBUF:CARG1->b
   |   stg L:RB, SBUF:CARG1->L
-  |   stg RC, SBUF:CARG1->p
+  |   stg RC, SBUF:CARG1->w
   |  stg PC, SAVE_PC
   |  brasl r14, extern lj_buf_putstr_ .. name
   |  // lgr CARG1, CRET1 (nop, CARG1==CRET1)


### PR DESCRIPTION
This PR fixes build issue on s390x introduced with commit 394fb6267acba72ee984edcd331ad1bbde72056a:
```vm_s390x.dasc:1807:60: error: 'SBuf' {aka 'struct SBuf'} has no member named 'p'```

Signed-off-by: Artiom Vaskov <artiom.vaskov@ibm.com>