### PR TITLE
This PR fixes s390x issues and enables CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ os: linux
 arch:
   - amd64
   - arm64
+  - s390x
 
 language: c
 
@@ -42,7 +43,7 @@ env:
   matrix:
   - LUAJIT_XCFLAGS="$LUAJIT_COMMON_XCFLAGS"
   - LUAJIT_XCFLAGS="-DLUAJIT_ENABLE_LUA52COMPAT $LUAJIT_COMMON_XCFLAGS" LUA52=1
-  - LUAJIT_XCFLAGS="-DLUAJIT_USE_VALGRIND -DLUAJIT_USE_SYSMALLOC -DLUAJIT_ENABLE_LUA52COMPAT $LUAJIT_COMMON_XCFLAGS" LUA52=1 FLAGS=-v
+  - LUAJIT_XCFLAGS="-DLUAJIT_USE_VALGRIND -DLUAJIT_USE_SYSMALLOC -DLUAJIT_ENABLE_LUA52COMPAT $LUAJIT_COMMON_XCFLAGS" LUA52=1 FLAGS=$( [ ${TRAVIS_CPU_ARCH} != "s390x" ] && echo '-v' )
   - LUAJIT_XCFLAGS="-DLUAJIT_DISABLE_GC64 -DLUAJIT_ENABLE_LUA52COMPAT $LUAJIT_COMMON_XCFLAGS" LUA52=1
 
 install:
@@ -55,6 +56,6 @@ script:
   - cd ../luajit2
   - make -j$JOBS CCDEBUG=-g Q= PREFIX=$LUAJIT_PREFIX CC=$CC XCFLAGS="$LUAJIT_XCFLAGS" > build.log 2>&1 || (cat build.log && exit 1)
   - sudo make install PREFIX=$LUAJIT_PREFIX > build.log 2>&1 || (cat build.log && exit 1)
-  - if [ ${TRAVIS_CPU_ARCH} != "arm64" ]; then PATH=/opt/luajit21/bin:$PATH prove -I. t; fi
+  - if [ ${TRAVIS_CPU_ARCH} == "amd64" ]; then PATH=/opt/luajit21/bin:$PATH prove -I. t; fi
   - cd ../luajit2-test-suite
   - ./run-tests -j $JOBS $FLAGS $LUAJIT_PREFIX

--- a/src/vm_s390x.dasc
+++ b/src/vm_s390x.dasc
@@ -1110,7 +1110,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  stg TAB:RC, -16(BASE)		// Store metatable as default result.
   |  lg STR:RC, (DISPATCH_GL(gcroot)+8*(GCROOT_MMNAME+MM_metatable))(DISPATCH)
   |  llgf RA, TAB:RB->hmask
-  |  n RA, STR:RC->hash
+  |  n RA, STR:RC->sid
   |  settp STR:RC, LJ_TSTR
   |  mghi RA, #NODE
   |  ag NODE:RA, TAB:RB->node
@@ -1213,35 +1213,25 @@ static void build_subroutines(BuildCtx *ctx)
   |.ffunc_1 next
   |  je >2				// Missing 2nd arg?
   |1:
-  |  lg CARG2, 0(BASE)
-  |  checktab CARG2, ->fff_fallback
-  |  lg L:RB, SAVE_L
-  |  stg BASE, L:RB->base		// Add frame since C call can throw.
-  |  stg BASE, L:RB->top		// Dummy frame length is ok.
+  |  lg CARG1, 0(BASE)
   |  lg PC, -8(BASE)
-  |  la CARG3, 8(BASE)
-  |  lgr CARG1, L:RB
-  |  stg PC, SAVE_PC			// Needed for ITERN fallback.
-  |  brasl r14, extern lj_tab_next	// (lua_State *L, GCtab *t, TValue *key)
-  |  // Flag returned in r2 (CRET1).
-  |  lg BASE, L:RB->base
-  |  ltr RD, CRET1;  je >3		// End of traversal?
-  |  // Copy key and value to results.
-  |  lg RB, 8(BASE)
-  |  lg RD, 16(BASE)
-  |  stg RB, -16(BASE)
-  |  stg RD, -8(BASE)
-  |->fff_res2:
-  |  lghi RD, 1+2
-  |  j ->fff_res
+  |  checktab CARG1, ->fff_fallback
+  |  lgr RB, BASE                       // Save BASE.
+  |  la CARG2, 8(BASE)
+  |  lay CARG3, -16(BASE)
+  |  brasl r14, extern lj_tab_next      // (GCtab *t, cTValue *key, TValue *o)
+  |  // 1=found, 0=end, -1=error returned in r2 (CRET1).
+  |  lgr BASE, RB                       // Restore BASE.
+  |  ltr RD, CRET1;  jh ->fff_res2      // Found key/value.
+  |  jl ->fff_fallback_2                // Invalid key.
+  |  // End of traversal: return nil.
+  |  lghi TMPR0, LJ_TNIL
+  |  stg TMPR0, -16(BASE)
+  |  j ->fff_res1
   |2:  // Set missing 2nd arg to nil.
   |  lghi TMPR0, LJ_TNIL
   |  stg TMPR0, 8(BASE)
   |  j <1
-  |3:  // End of traversal: return nil.
-  |  lghi TMPR0, LJ_TNIL
-  |  stg TMPR0, -16(BASE)
-  |  j ->fff_res1
   |
   |.ffunc_1 pairs
   |  lg TAB:RB, 0(BASE)
@@ -1281,7 +1271,9 @@ static void build_subroutines(BuildCtx *ctx)
   |  cghi TMPR0, LJ_TNIL;  je ->fff_res0
   |  // Copy array slot.
   |  stg TMPR0, -8(BASE)
-  |  j ->fff_res2
+  |->fff_res2:
+  |  lghi RD, 1+2
+  |  j ->fff_res
   |2:  // Check for empty hash part first. Otherwise call C function.
   |  lt TMPR0, TAB:RB->hmask; je ->fff_res0
   |  lgr CARG1, TAB:RB
@@ -2134,6 +2126,11 @@ static void build_subroutines(BuildCtx *ctx)
   |  stg r0, 0
 #ifdef LUA_USE_ASSERT
 #endif
+  |
+  |->vm_next:
+  |.if JIT
+  |  NYI  // On big-endian.
+  |.endif
   |
   |//-----------------------------------------------------------------------
   |//-- FFI helper functions -----------------------------------------------
@@ -3117,7 +3114,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  checktab TAB:RB, ->vmeta_tgets
     |->BC_TGETS_Z:	// RB = GCtab *, RC = GCstr *
     |  l TMPR1, TAB:RB->hmask
-    |  n TMPR1, STR:RC->hash
+    |  n TMPR1, STR:RC->sid
     |  lgfr TMPR1, TMPR1
     |  mghi TMPR1, #NODE
     |  ag NODE:TMPR1, TAB:RB->node
@@ -3250,7 +3247,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  checktab TAB:RB, ->vmeta_tsets
     |->BC_TSETS_Z:	// RB = GCtab *, RC = GCstr *
     |  l TMPR1, TAB:RB->hmask
-    |  n TMPR1, STR:RC->hash
+    |  n TMPR1, STR:RC->sid
     |  lgfr TMPR1, TMPR1
     |  mghi TMPR1, #NODE
     |  mvi TAB:RB->nomm, 0		// Clear metamethod cache.
@@ -3514,10 +3511,11 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     break;
 
   case BC_ITERN:
-    |  ins_A	// RA = base, (RB = nresults+1, RC = nargs+1 (2+1))
     |.if JIT
-    |  // NYI: add hotloop, record BC_ITERN.
+    |  hotloop RB // NYI: add hotloop, record BC_ITERN.
     |.endif
+    |->vm_IITERN:
+    |  ins_A	// RA = base, (RB = nresults+1, RC = nargs+1 (2+1))
     |  sllg RA, RA, 3
     |  lg TAB:RB, -16(RA, BASE)
     |  cleartp TAB:RB
@@ -3927,7 +3925,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  // Note: RA/RD is only used by trace recorder to determine scope/extent
     |  // This opcode does NOT jump, it's only purpose is to detect a hot loop.
     |.if JIT
-    |  hotloop RBd
+    |  hotloop RB
     |.endif
     | // Fall through. Assumes BC_ILOOP follows and ins_A is a no-op.
     break;


### PR DESCRIPTION
This PR fixes issue https://github.com/openresty/luajit2/issues/136
and breakage introduced by commit 5980ef945c459625a21d8f397fb8a4cf043c1771 seen in
https://github.com/kubernetes/ingress-nginx/issues/6504 on s390x.

Additionally implemented:
- Table traversal changes for s390x introduced in commits c6f5ef6 and bb0f241.
- CI (valgrind disabled for s390x because of unimplemented instruction).

Signed-off-by: Artiom Vaskov <artiom.vaskov@ibm.com>