### PR TITLE
Do not eliminate HSTORE over nkeys and clone

### DIFF
--- a/src/lj_opt_mem.c
+++ b/src/lj_opt_mem.c
@@ -369,9 +369,9 @@ TRef LJ_FASTCALL lj_opt_dse_ahstore(jit_State *J)
 	** since they are followed by at least one guarded VLOAD.
 	*/
 	for (ir = IR(J->cur.nins-1); ir > store; ir--)
-	  if (irt_isguard(ir->t) || ir->o == IR_ALEN || 
-        (ir->o == IR_CALLL && ir->op2 == IRCALL_lj_tab_nkeys) || 
-        (ir->o == IR_CALLS && ir->op2 == IRCALL_lj_tab_clone))
+	  if (irt_isguard(ir->t) || ir->o == IR_ALEN ||
+              (ir->o == IR_CALLL && ir->op2 == IRCALL_lj_tab_nkeys) ||
+              (ir->o == IR_CALLS && ir->op2 == IRCALL_lj_tab_clone))
 	    goto doemit;  /* No elimination possible. */
 	/* Remove redundant store from chain and replace with NOP. */
 	*refp = store->prev;

--- a/src/lj_opt_mem.c
+++ b/src/lj_opt_mem.c
@@ -369,7 +369,9 @@ TRef LJ_FASTCALL lj_opt_dse_ahstore(jit_State *J)
 	** since they are followed by at least one guarded VLOAD.
 	*/
 	for (ir = IR(J->cur.nins-1); ir > store; ir--)
-	  if (irt_isguard(ir->t) || ir->o == IR_ALEN)
+	  if (irt_isguard(ir->t) || ir->o == IR_ALEN || 
+        (ir->o == IR_CALLL && ir->op2 == IRCALL_lj_tab_nkeys) || 
+        (ir->o == IR_CALLS && ir->op2 == IRCALL_lj_tab_clone))
 	    goto doemit;  /* No elimination possible. */
 	/* Remove redundant store from chain and replace with NOP. */
 	*refp = store->prev;


### PR DESCRIPTION
Prevent elimination of HSTORE instruction over `table.nkeys` and `table.clone` calls which could rely on the store. This should fix https://github.com/openresty/luajit2/issues/147.