### PR TITLE
Fix alias check in lj_opt_fwd_alen

### DIFF
--- a/src/lj_opt_mem.c
+++ b/src/lj_opt_mem.c
@@ -434,7 +434,7 @@ TRef LJ_FASTCALL lj_opt_fwd_alen(jit_State *J)
 	    fins->op2 = aref->op2;  /* Set ALEN hint. */
 	  }
 	  goto doemit;  /* Conflicting store, possibly giving a hint. */
-	} else if (aa_table(J, tab, fref->op1) == ALIAS_NO) {
+	} else if (aa_table(J, tab, fref->op1) != ALIAS_NO) {
 	  goto doemit;  /* Conflicting store. */
 	}
 	sref = store->prev;


### PR DESCRIPTION
The function assumes no aliasing when there is one.

Test case (alen.lua):
```lua
local t = {}
local ta = t
local s = 0
for i = 1, 1000 do
  ta[i] = i
  s = s + #t
end
print(s)
```
Running the test case without fix:
```bash
$ luajit -j off alen.lua
500500
$ luajit -j on alen.lua
339799
```
After fix:
```bash
$ luajit -j off alen.lua
500500
$ luajit -j on alen.lua
500500
```