### PR TITLE
Fix math.floor() and math.ceil()

### DIFF
--- a/dynasm/dasm_s390x.lua
+++ b/dynasm/dasm_s390x.lua
@@ -823,6 +823,7 @@ map_op = {
   esxtr_2 =	"0000b3ef0000RRE",
   ex_2 =	"000044000000RX-a",
   exrl_2 =	"c60000000000RIL-b",
+  fidbra_4 =	"0000b35f0000RRF-e",
   fidr_2 =	"0000b37f0000RRE",
   fier_2 =	"0000b3770000RRE",
   fixr_2 =	"0000b3670000RRE",

--- a/src/vm_s390x.dasc
+++ b/src/vm_s390x.dasc
@@ -2098,11 +2098,13 @@ static void build_subroutines(BuildCtx *ctx)
   |// Value to round is in f0. May clobber f0-f7 and r0. Return address is r14.
   |.macro vm_round, name, mask
   |->name:
+  |  ldr f4, f0
   |  lghi r0, 1
   |  cdfbr f1, r0
   |  didbr f0, f2, f1, mask // f0=remainder, f2=quotient.
+  |  fidbra f4, mask, f4, 0
+  |  ldr f0, f4
   |  jnle >1
-  |  ldr f0, f2
   |  br r14
   |1: // partial remainder (sanity check)
   |  stg r0, 0


### PR DESCRIPTION
This fixes the issue of math.floor() and math.ceil() giving nan for +inf and -inf.

Issue fixed #176 