### PR TITLE
PPC/e500 with SPE enabled: use soft float instead of failing

### DIFF
--- a/src/lj_arch.h
+++ b/src/lj_arch.h
@@ -291,7 +291,7 @@
 #define LJ_ARCH_NAME		"ppc"
 
 #if !defined(LJ_ARCH_HASFPU)
-#if defined(_SOFT_FLOAT) || defined(_SOFT_DOUBLE)
+#if defined(_SOFT_FLOAT) || defined(_SOFT_DOUBLE) || defined(__NO_FPRS__)
 #define LJ_ARCH_HASFPU		0
 #else
 #define LJ_ARCH_HASFPU		1
@@ -299,7 +299,7 @@
 #endif
 
 #if !defined(LJ_ABI_SOFTFP)
-#if defined(_SOFT_FLOAT) || defined(_SOFT_DOUBLE)
+#if defined(_SOFT_FLOAT) || defined(_SOFT_DOUBLE) || defined(__NO_FPRS__)
 #define LJ_ABI_SOFTFP		1
 #else
 #define LJ_ABI_SOFTFP		0
@@ -516,9 +516,6 @@
 #error "No support for ILP32 model on ARM64"
 #endif
 #elif LJ_TARGET_PPC
-#if defined(__NO_FPRS__) && !defined(_SOFT_FLOAT)
-#error "No support for PPC/e500 anymore (use LuaJIT 2.0)"
-#endif
 #elif LJ_TARGET_MIPS32
 #if !((defined(_MIPS_SIM_ABI32) && _MIPS_SIM == _MIPS_SIM_ABI32) || (defined(_ABIO32) && _MIPS_SIM == _ABIO32))
 #error "Only o32 ABI supported for MIPS32"


### PR DESCRIPTION
This allows building LuaJit for systems with Power ISA SPE
extension[^1] support by using soft float on LuaJit side.

While e500 CPU cores support SPE instruction set extension
allowing them to perform floating point arithmetic natively,
this isn't required. They can function with software floating
point to integer arithmetic translation as well,
just like FPU-less PowerPC CPUs without SPE support.

Therefore I see no need to prevent them from running LuaJit
explicitly.

[^1]: https://www.nxp.com/docs/en/reference-manual/SPEPEM.pdf

Signed-off-by: Pali Rohár <pali@kernel.org>
Signed-off-by: Šimon Bořek <simon.borek@nic.cz>