### PR TITLE
 Segmentation fault while running test-suite and iter.lua Test case f…

### DIFF
--- a/src/vm_ppc.dasc
+++ b/src/vm_ppc.dasc
@@ -977,8 +977,11 @@ static void build_subroutines(BuildCtx *ctx)
   |.if FFI
   |  cmplwi TMP0, 1
   |.endif
-  |     lwz PC, -16(RB)			// Restore PC from [cont|PC].
-  |   subi TMP2, RD, 8
+  |// PC value corrected to avoid segfault
+  |   lwz PC, FRAME_CONTPC(RB)        // Restore PC from [cont|PC].
+  |	addi BASEP4, BASE, 4 
+  |	addi TMP2, RD, WORD_HI-8
+  |	lwz TMP1, LFUNC:TMP1->pc
   |   stwx TISNIL, RA, TMP2		// Ensure one valid arg.
   |.if P64
   |   ld TMP3, 0(DISPATCH)
@@ -986,7 +989,9 @@ static void build_subroutines(BuildCtx *ctx)
   |.if FFI
   |  ble >1
   |.endif
-  |    lwz TMP1, LFUNC:TMP1->pc
+  |.if P64
+  |  add TMP0, TMP0, TMP3
+  |.endif
   |    lwz KBASE, PC2PROTO(k)(TMP1)
   |  // BASE = base, RA = resultptr, RB = meta base
   |  mtctr TMP0
@@ -1715,24 +1720,33 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |//-- Base library: iterators -------------------------------------------
   |
-  |.ffunc_1 next
-  |   stwx TISNIL, BASE, NARGS8:RC	// Set missing 2nd arg to nil.
-  |  checktab CARG3
+  |.ffunc next
+  |  cmplwi NARGS8:RC, 8
+  |    lwz TAB:CARG1, WORD_LO(BASE)
+  |  blt ->fff_fallback
+  |.if ENDIAN_LE
+  |   add TMP1, BASE, NARGS8:RC
+  |   stw TISNIL, WORD_HI(TMP1)         // Set missing 2nd arg to nil.
+  |.else
+  |   stwx TISNIL, BASE, NARGS8:RC      // Set missing 2nd arg to nil.
+  |.endif
   |   lwz PC, FRAME_PC(BASE)
-  |  bne ->fff_fallback
+  |   stp BASE, L->base                 // Add frame since C call can throw.
+  |   stp BASE, L->top                  // Dummy frame length is ok.
   |  la CARG2, 8(BASE)
   |  la CARG3, -8(BASE)
-  |  bl extern lj_tab_next		// (GCtab *t, cTValue *key, TValue *o)
+  |   stw PC, SAVE_PC
+  |  bl extern lj_tab_next      // (GCtab *t, cTValue *key,TValue *o)
   |  // Returns 1=found, 0=end, -1=error.
   |  cmpwi CRET1, 0
   |   la RA, -8(BASE)
   |   li RD, (2+1)*8
-  |  bgt ->fff_res			// Found key/value.
+  |   bgt ->fff_res                      // Found key/value.
   |   li CARG3, LJ_TNIL
-  |  beq ->fff_restv			// End of traversal: return nil.
+  |   beq ->fff_restv                    // End of traversal: return nil.
   |   lwz CFUNC:RB, FRAME_FUNC(BASE)
   |   li NARGS8:RC, 2*8
-  |  b ->fff_fallback			// Invalid key.
+  |   b ->fff_fallback                   // Invalid key.
   |
   |.ffunc_1 pairs
   |  checktab CARG3
@@ -5667,10 +5681,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  crand 4*cr0+eq, 4*cr0+eq, 4*cr7+eq
     |    add TMP3, PC, TMP0
     |  bne cr0, >5
-    |  lus TMP1, (LJ_KEYINDEX >> 16)
-    |  ori TMP1, TMP1, (LJ_KEYINDEX & 0xffff)
-    |  stw ZERO, -4(RA)			// Initialize control var.
-    |  stw TMP1, -8(RA)
+    |  lus TMP1, 0xfffe
+    |  ori TMP1, TMP1, 0x7fff
+    |  stw ZERO, WORD_LO-8(RA)          // Initialize control var.
+    |  stw TMP1, WORD_HI-8(RA)
     |    addis PC, TMP3, -(BCBIAS_J*4 >> 16)
     |1:
     |  ins_next

--- a/src/vm_ppc.dasc
+++ b/src/vm_ppc.dasc
@@ -977,11 +977,16 @@ static void build_subroutines(BuildCtx *ctx)
   |.if FFI
   |  cmplwi TMP0, 1
   |.endif
+  |.if P64
   |// PC value corrected to avoid segfault
   |   lwz PC, FRAME_CONTPC(RB)        // Restore PC from [cont|PC].
   |	addi BASEP4, BASE, 4 
   |	addi TMP2, RD, WORD_HI-8
   |	lwz TMP1, LFUNC:TMP1->pc
+  |.else
+  |     lwz PC, -16(RB)			// Restore PC from [cont|PC].
+  |   subi TMP2, RD, 8
+  |.endif
   |   stwx TISNIL, RA, TMP2		// Ensure one valid arg.
   |.if P64
   |   ld TMP3, 0(DISPATCH)
@@ -991,6 +996,8 @@ static void build_subroutines(BuildCtx *ctx)
   |.endif
   |.if P64
   |  add TMP0, TMP0, TMP3
+  |.else
+  |    lwz TMP1, LFUNC:TMP1->pc
   |.endif
   |    lwz KBASE, PC2PROTO(k)(TMP1)
   |  // BASE = base, RA = resultptr, RB = meta base
@@ -1720,6 +1727,7 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |//-- Base library: iterators -------------------------------------------
   |
+  |.if P64
   |.ffunc next
   |  cmplwi NARGS8:RC, 8
   |    lwz TAB:CARG1, WORD_LO(BASE)
@@ -1737,6 +1745,16 @@ static void build_subroutines(BuildCtx *ctx)
   |  la CARG3, -8(BASE)
   |   stw PC, SAVE_PC
   |  bl extern lj_tab_next      // (GCtab *t, cTValue *key,TValue *o)
+  |.else
+  |.ffunc_1 next
+  |   stwx TISNIL, BASE, NARGS8:RC	// Set missing 2nd arg to nil.
+  |  checktab CARG3
+  |   lwz PC, FRAME_PC(BASE)
+  |  bne ->fff_fallback
+  |  la CARG2, 8(BASE)
+  |  la CARG3, -8(BASE)
+  |  bl extern lj_tab_next		// (GCtab *t, cTValue *key, TValue *o)
+  |.endif
   |  // Returns 1=found, 0=end, -1=error.
   |  cmpwi CRET1, 0
   |   la RA, -8(BASE)
@@ -5681,10 +5699,17 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  crand 4*cr0+eq, 4*cr0+eq, 4*cr7+eq
     |    add TMP3, PC, TMP0
     |  bne cr0, >5
+    |.if P64
     |  lus TMP1, 0xfffe
     |  ori TMP1, TMP1, 0x7fff
     |  stw ZERO, WORD_LO-8(RA)          // Initialize control var.
     |  stw TMP1, WORD_HI-8(RA)
+    |.else
+    |  lus TMP1, (LJ_KEYINDEX >> 16)
+    |  ori TMP1, TMP1, (LJ_KEYINDEX & 0xffff)
+    |  stw ZERO, -4(RA)			// Initialize control var.
+    |  stw TMP1, -8(RA)
+    |.endif
     |    addis PC, TMP3, -(BCBIAS_J*4 >> 16)
     |1:
     |  ins_next


### PR DESCRIPTION
Hi 
 Following segmentation fault has been observed and fixed while testing few products on ppc64le .  

Test failing on ppc64le, when i have tested with luajit2-test-suite using luajit

[root@2092f12255fb luajit2-test-suite]# gdb --args luajit test/misc/tonumber_scan.lua

Starting program: /usr/local/bin/luajit test/misc/tonumber_scan.lua

Program received signal SIGSEGV, Segmentation fault.
0x00000000000030e8 in ?? ()
Missing separate debuginfos, use: yum debuginfo-install glibc-2.28-189.5.el8_6.ppc64le libgcc-8.5.0-15.el8.ppc64le
(gdb) bt
#0 0x00000000000030e8 in ?? ()
https://github.com/openresty/luajit2/pull/1 0x000000001003fcf4 in lj_BC_FUNCC ()
https://github.com/openresty/luajit2/pull/2 0x000000001001cb68 in lua_pcall (L=0x79600380, nargs=0, nresults=-1, errfunc=2) at lj_api.c:1145
https://github.com/openresty/luajit2/pull/3 0x0000000010004de8 in docall (L=0x79600380, narg=0, clear=0) at luajit.c:122
https://github.com/openresty/luajit2/issues/4 0x0000000010005ae4 in handle_script (L=0x79600380, argx=0x7ffffffffb30) at luajit.c:292
https://github.com/openresty/luajit2/issues/5 0x00000000100069ec in pmain (L=0x79600380) at luajit.c:550
https://github.com/openresty/luajit2/issues/6 0x000000001003fcf4 in lj_BC_FUNCC ()
https://github.com/openresty/luajit2/issues/7 0x000000001001cda0 in lua_cpcall (L=0x79600380, func=0x10006808 , ud=0x0) at lj_api.c:1173
https://github.com/openresty/luajit2/issues/8 0x0000000010006b8c in main (argc=2, argv=0x7ffffffffb28) at luajit.c:581


we have verified this locally with openresty version 1.21.4.1 . 

[root@APIC1 luajit2-test-suite]# ./run-tests -v  /usr/local/bin/luajit/  /usr/local/bin/luajit/bin/luajit  gcc g++ test/misc/iter.lua
=== test/misc/iter.lua
All tests successful.
[root@APIC1 luajit2-test-suite]#
 
Also verified the luajit-test-suite test cases . 