### PR TITLE
ppc64le support

### DIFF
--- a/src/lj_arch.h
+++ b/src/lj_arch.h
@@ -538,15 +538,6 @@
 #error "No support for ILP32 model on ARM64"
 #undef LJ_TARGET_ARM64
 #endif
-#elif LJ_TARGET_PPC
-#if defined(_LITTLE_ENDIAN) && (!defined(_BYTE_ORDER) || (_BYTE_ORDER == _LITTLE_ENDIAN))
-#error "No support for little-endian PPC32"
-#undef LJ_TARGET_PPC
-#endif
-#if defined(__NO_FPRS__) && !defined(_SOFT_FLOAT)
-#error "No support for PPC/e500, use LuaJIT 2.0"
-#undef LJ_TARGET_PPC
-#endif
 #elif LJ_TARGET_MIPS32
 #if !((defined(_MIPS_SIM_ABI32) && _MIPS_SIM == _MIPS_SIM_ABI32) || (defined(_ABIO32) && _MIPS_SIM == _ABIO32))
 #error "Only o32 ABI supported for MIPS32"
@@ -706,6 +697,10 @@ extern void *LJ_WIN_LOADLIBA(const char *path);
 #endif
 #endif
 
+#if LUAJIT_TARGET == LUAJIT_ARCH_PPC && LJ_ARCH_ENDIAN == LUAJIT_LE
+#define LJ_NO_UNWIND            0
+#define LJ_UNWIND_EXT           0
+#else
 #if defined(LUAJIT_NO_UNWIND) || __GNU_COMPACT_EH__ || defined(__symbian__) || LJ_TARGET_IOS || LJ_TARGET_PS3 || LJ_TARGET_PS4 || LJ_TARGET_PS5
 #define LJ_NO_UNWIND		1
 #endif
@@ -715,6 +710,7 @@ extern void *LJ_WIN_LOADLIBA(const char *path);
 #else
 #define LJ_UNWIND_EXT		0
 #endif
+#endif  //#if LUAJIT_TARGET == LUAJIT_ARCH_PPC && LJ_ARCH_ENDIAN == LUAJIT_LE
 
 #if LJ_UNWIND_EXT && LJ_HASJIT && !LJ_TARGET_ARM && !(LJ_ABI_WIN && LJ_TARGET_X86)
 #define LJ_UNWIND_JIT		1

--- a/src/lj_ccall.c
+++ b/src/lj_ccall.c
@@ -1393,9 +1393,8 @@ int lj_ccall_func(lua_State *L, GCcdata *cd)
     ct = ctype_rawchild(cts, ct);
   }
   if (ctype_isfunc(ct->info)) {
-    CCallState cc;
+    CCallState cc = {0};
     int gcsteps, ret;
-    memset(&cc, 0, sizeof(CCallState));
     cc.func = (void (*)(void))cdata_getptr(cdataptr(cd), sz);
     gcsteps = ccall_set_args(L, cts, ct, &cc);
     ct = (CType *)((intptr_t)ct-(intptr_t)cts->tab);

--- a/src/lj_ccall.c
+++ b/src/lj_ccall.c
@@ -1395,6 +1395,7 @@ int lj_ccall_func(lua_State *L, GCcdata *cd)
   if (ctype_isfunc(ct->info)) {
     CCallState cc;
     int gcsteps, ret;
+    memset(&cc, 0, sizeof(CCallState));
     cc.func = (void (*)(void))cdata_getptr(cdataptr(cd), sz);
     gcsteps = ccall_set_args(L, cts, ct, &cc);
     ct = (CType *)((intptr_t)ct-(intptr_t)cts->tab);

--- a/src/lj_ccall.h
+++ b/src/lj_ccall.h
@@ -181,6 +181,7 @@ typedef union FPRArg {
   (CCALL_NARG_GPR > CCALL_NRET_GPR ? CCALL_NARG_GPR : CCALL_NRET_GPR)
 #define CCALL_NUM_FPR \
   (CCALL_NARG_FPR > CCALL_NRET_FPR ? CCALL_NARG_FPR : CCALL_NRET_FPR)
+#define CCALL_MAXSTACK          32
 
 /* Check against constants in lj_ctype.h. */
 LJ_STATIC_ASSERT(CCALL_NUM_GPR <= CCALL_MAX_GPR);

--- a/src/lj_parse.c
+++ b/src/lj_parse.c
@@ -1753,6 +1753,7 @@ static void expr_table(LexState *ls, ExpDesc *e)
     if (expr_isk(&key) && key.k != VKNIL &&
 	(key.k == VKSTR || expr_isk_nojump(&val))) {
       TValue k, *v;
+      memset(&k, 0, sizeof(TValue));
       if (!t) {  /* Create template table on demand. */
 	BCReg kidx;
 	t = lj_tab_new(fs->L, needarr ? narr : 0, hsize2hbits(nhash));

--- a/src/lj_parse.c
+++ b/src/lj_parse.c
@@ -1752,8 +1752,8 @@ static void expr_table(LexState *ls, ExpDesc *e)
     expr(ls, &val);
     if (expr_isk(&key) && key.k != VKNIL &&
 	(key.k == VKSTR || expr_isk_nojump(&val))) {
-      TValue k, *v;
-      memset(&k, 0, sizeof(TValue));
+      TValue k = {0};
+      TValue *v;
       if (!t) {  /* Create template table on demand. */
 	BCReg kidx;
 	t = lj_tab_new(fs->L, needarr ? narr : 0, hsize2hbits(nhash));

--- a/src/vm_ppc.dasc
+++ b/src/vm_ppc.dasc
@@ -977,8 +977,11 @@ static void build_subroutines(BuildCtx *ctx)
   |.if FFI
   |  cmplwi TMP0, 1
   |.endif
-  |     lwz PC, -16(RB)			// Restore PC from [cont|PC].
-  |   subi TMP2, RD, 8
+  |// PC value corrected to avoid segfault
+  |   lwz PC, FRAME_CONTPC(RB)        // Restore PC from [cont|PC].
+  |	addi BASEP4, BASE, 4 
+  |	addi TMP2, RD, WORD_HI-8
+  |	lwz TMP1, LFUNC:TMP1->pc
   |   stwx TISNIL, RA, TMP2		// Ensure one valid arg.
   |.if P64
   |   ld TMP3, 0(DISPATCH)
@@ -986,7 +989,9 @@ static void build_subroutines(BuildCtx *ctx)
   |.if FFI
   |  ble >1
   |.endif
-  |    lwz TMP1, LFUNC:TMP1->pc
+  |.if P64
+  |  add TMP0, TMP0, TMP3
+  |.endif
   |    lwz KBASE, PC2PROTO(k)(TMP1)
   |  // BASE = base, RA = resultptr, RB = meta base
   |  mtctr TMP0
@@ -1715,14 +1720,23 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |//-- Base library: iterators -------------------------------------------
   |
-  |.ffunc_1 next
-  |   stwx TISNIL, BASE, NARGS8:RC	// Set missing 2nd arg to nil.
-  |  checktab CARG3
+  |.ffunc next
+  |  cmplwi NARGS8:RC, 8
+  |    lwz TAB:CARG1, WORD_LO(BASE)
+  |  blt ->fff_fallback
+  |.if ENDIAN_LE
+  |   add TMP1, BASE, NARGS8:RC
+  |   stw TISNIL, WORD_HI(TMP1)         // Set missing 2nd arg to nil.
+  |.else
+  |   stwx TISNIL, BASE, NARGS8:RC      // Set missing 2nd arg to nil.
+  |.endif
   |   lwz PC, FRAME_PC(BASE)
-  |  bne ->fff_fallback
+  |   stp BASE, L->base                 // Add frame since C call can throw.
+  |   stp BASE, L->top                  // Dummy frame length is ok.
   |  la CARG2, 8(BASE)
   |  la CARG3, -8(BASE)
-  |  bl extern lj_tab_next		// (GCtab *t, cTValue *key, TValue *o)
+  |   stw PC, SAVE_PC
+  |  bl extern lj_tab_next      // (GCtab *t, cTValue *key,TValue *o)
   |  // Returns 1=found, 0=end, -1=error.
   |  cmpwi CRET1, 0
   |   la RA, -8(BASE)
@@ -3539,7 +3553,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  .endif
   |   cmpwi cr1, CARG3, 0
   |  mr TMP2, sp
-  |   addic. CARG2, CARG2, -4
+  |   addic. CARG2, CARG2, -PSIZE
   |  .if GPR64
   |  stdux sp, sp, TMP1
   |  .else
@@ -5680,10 +5694,10 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  crand 4*cr0+eq, 4*cr0+eq, 4*cr7+eq
     |    add TMP3, PC, TMP0
     |  bne cr0, >5
-    |  lus TMP1, (LJ_KEYINDEX >> 16)
-    |  ori TMP1, TMP1, (LJ_KEYINDEX & 0xffff)
-    |  stw ZERO, -4(RA)			// Initialize control var.
-    |  stw TMP1, -8(RA)
+    |  lus TMP1, 0xfffe
+    |  ori TMP1, TMP1, 0x7fff
+    |  stw ZERO, WORD_LO-8(RA)          // Initialize control var.
+    |  stw TMP1, WORD_HI-8(RA)
     |    addis PC, TMP3, -(BCBIAS_J*4 >> 16)
     |1:
     |  ins_next


### PR DESCRIPTION
```
+ ./run-tests -v /usr/local
=== test/ffi/ffi_arith_ptr.lua
=== test/ffi/ffi_bit64.lua
=== test/ffi/ffi_bitfield.lua
=== test/ffi/ffi_call.lua
=== test/ffi/ffi_callback.lua
=== test/ffi/ffi_const.lua
=== test/ffi/ffi_convert.lua
=== test/ffi/ffi_copy_fill.lua
=== test/ffi/ffi_enum.lua
=== test/ffi/ffi_err.lua
=== test/ffi/ffi_gcstep_recursive.lua
=== test/ffi/ffi_istype.lua
=== test/ffi/ffi_jit_arith.lua
=== test/ffi/ffi_jit_array.lua
=== test/ffi/ffi_jit_call.lua
=== test/ffi/ffi_jit_complex.lua
=== test/ffi/ffi_jit_conv.lua
=== test/ffi/ffi_jit_misc.lua
=== test/ffi/ffi_jit_struct.lua
=== test/ffi/ffi_lex_number.lua
=== test/ffi/ffi_meta_tostring.lua
=== test/ffi/ffi_metatype.lua
=== test/ffi/ffi_new.lua
=== test/ffi/ffi_nosink.lua
=== test/ffi/ffi_parse_array.lua
=== test/ffi/ffi_parse_basic.lua
=== test/ffi/ffi_parse_cdef.lua
=== test/ffi/ffi_parse_struct.lua
=== test/ffi/ffi_redir.lua
=== test/ffi/ffi_sink.lua
=== test/ffi/ffi_tabov.lua
=== test/ffi/ffi_type_punning.lua
=== test/ffi/unsink_64_kptr.lua
=== test/misc/ack.lua
Ack(3,1): 13
=== test/misc/ack_notail.lua
Ack(3,1): 13
=== test/misc/alias_alloc.lua
=== test/misc/api_call.lua
=== test/misc/argcheck.lua
=== test/misc/assign_tset_prevnil.lua
=== test/misc/assign_tset_tmp.lua
=== test/misc/bit_op.lua
=== test/misc/cat_jit.lua
=== test/misc/catch_wrap.lua
=== test/misc/compare.lua
=== test/misc/constov.lua
=== test/misc/coro_traceback.lua
=== test/misc/coro_yield.lua
=== test/misc/debug_gc.lua
=== test/misc/debug_meta.lua
=== test/misc/dse_array.lua
=== test/misc/dse_field.lua
=== test/misc/dualnum.lua
=== test/misc/exit_frame.lua
=== test/misc/exit_growstack.lua
=== test/misc/exit_jfuncf.lua
=== test/misc/fac.lua
1
=== test/misc/fastfib.lua
Fib(1): 1
=== test/misc/fib.lua
Fib(1): 1
=== test/misc/for_dir.lua
=== test/misc/fori_coerce.lua
=== test/misc/fuse.lua
=== test/misc/fwd_hrefk_rollback.lua
=== test/misc/fwd_tnew_tdup.lua
=== test/misc/fwd_upval.lua
=== test/misc/gc_rechain.lua
=== test/misc/gc_trace.lua
=== test/misc/gcstep.lua
=== test/misc/getfenv.lua
=== test/misc/goto.lua
=== test/misc/hook_active.lua
=== test/misc/hook_line.lua
=== test/misc/hook_norecord.lua
=== test/misc/hook_record.lua
=== test/misc/hook_top.lua
=== test/misc/hstore_elimination.lua
=== test/misc/iter.lua
=== test/misc/jit_flush.lua
=== test/misc/jloop-itern-stack-check-fix.lua
=== test/misc/kfold.lua
=== test/misc/libfuncs.lua
=== test/misc/lightud.lua
=== test/misc/loop_unroll.lua
=== test/misc/math_random.lua
=== test/misc/meta_arith.lua
=== test/misc/meta_arith_jit.lua
=== test/misc/meta_call.lua
=== test/misc/meta_cat.lua
=== test/misc/meta_comp.lua
=== test/misc/meta_comp_jit.lua
=== test/misc/meta_eq.lua
=== test/misc/meta_eq_jit.lua
=== test/misc/meta_framegap.lua
=== test/misc/meta_getset.lua
=== test/misc/meta_len.lua
=== test/misc/meta_nomm.lua
=== test/misc/meta_pairs.lua
=== test/misc/meta_tget.lua
=== test/misc/meta_tget_nontab.lua
=== test/misc/meta_tset.lua
=== test/misc/meta_tset_nilget.lua
=== test/misc/meta_tset_resize.lua
=== test/misc/meta_tset_str.lua
=== test/misc/modulo.lua
=== test/misc/multi_result_call_next.lua
=== test/misc/nsieve.lua
Primes up to        1        0
=== test/misc/pairs_bug.lua
=== test/misc/parse_andor.lua
=== test/misc/parse_comp.lua
=== test/misc/parse_esc.lua
=== test/misc/parse_hex.lua
=== test/misc/parse_misc.lua
=== test/misc/pcall_jit.lua
=== test/misc/phi_conv.lua
=== test/misc/phi_copyspill.lua
=== test/misc/phi_ref.lua
=== test/misc/phi_rot18.lua
=== test/misc/phi_rot8.lua
=== test/misc/phi_rot9.lua
=== test/misc/phi_rotx.lua
=== test/misc/recsum.lua
=== test/misc/recsump.lua
=== test/misc/recurse_deep.lua
=== test/misc/recurse_tail.lua
=== test/misc/select.lua
=== test/misc/self.lua
=== test/misc/sink_alloc.lua
=== test/misc/sink_nosink.lua
=== test/misc/snap_gcexit.lua
=== test/misc/snap_top.lua
=== test/misc/snap_top2.lua
=== test/misc/sort.lua
=== test/misc/stack_gc.lua
=== test/misc/stack_purge.lua
=== test/misc/stackov.lua
=== test/misc/stackovc.lua
=== test/misc/stitch.lua
=== test/misc/strcmp.lua
=== test/misc/string_byte.lua
=== test/misc/string_char.lua
=== test/misc/string_dump.lua
=== test/misc/string_op.lua
=== test/misc/string_sub.lua
=== test/misc/string_sub_opt.lua
=== test/misc/table_alias.lua
=== test/misc/table_chain_bug_LuaJIT_494.lua
=== test/misc/table_insert.lua
=== test/misc/table_misc.lua
=== test/misc/table_remove.lua
=== test/misc/tak.lua
2
=== test/misc/tcall_base.lua
=== test/misc/tcall_loop.lua
=== test/misc/tlen_loop.lua
=== test/misc/tnew_tdup.lua
=== test/misc/tonumber_scan.lua
=== test/misc/tonumber_tostring.lua
=== test/misc/uclo.lua
=== test/misc/unordered.lua
=== test/misc/unordered_jit.lua
=== test/misc/vararg_jit.lua
=== test/misc/wbarrier.lua
=== test/misc/wbarrier_jit.lua
=== test/misc/wbarrier_obar.lua
=== test/misc/xpcall_jit.lua
=== test/misc/iter-bug.lua
=== test/misc/jit_record.lua
10
63
=== test/sysdep/catch_cpp.lua
=== test/sysdep/ffi_include_gtk.lua
=== test/sysdep/ffi_include_std.lua
/tmp/__tmp.c:1: warning: "__float128" redefined
 #define __float128 double

<built-in>: note: this is the location of the previous definition
=== test/sysdep/ffi_lib_c.lua
=== test/sysdep/ffi_lib_z.lua
=== test/unportable/math_special.lua
All tests successful.

```