### PR TITLE
[ppc64le] Aligned code as per other archs for next_1 function and relevant code changes

### DIFF
--- a/src/vm_ppc.dasc
+++ b/src/vm_ppc.dasc
@@ -1720,9 +1720,10 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |//-- Base library: iterators -------------------------------------------
   |
-  |.ffunc next
+  |.ffunc_1 next
   |  cmplwi NARGS8:RC, 8
   |    lwz TAB:CARG1, WORD_LO(BASE)
+  |    lwz CARG2, WORD_HI(BASE)
   |  blt ->fff_fallback
   |.if ENDIAN_LE
   |   add TMP1, BASE, NARGS8:RC
@@ -1730,7 +1731,9 @@ static void build_subroutines(BuildCtx *ctx)
   |.else
   |   stwx TISNIL, BASE, NARGS8:RC      // Set missing 2nd arg to nil.
   |.endif
+  |  checktab CARG2
   |   lwz PC, FRAME_PC(BASE)
+  |  bne ->fff_fallback
   |   stp BASE, L->base                 // Add frame since C call can throw.
   |   stp BASE, L->top                  // Dummy frame length is ok.
   |  la CARG2, 8(BASE)
@@ -5703,8 +5706,8 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  crand 4*cr0+eq, 4*cr0+eq, 4*cr7+eq
     |    add TMP3, PC, TMP0
     |  bne cr0, >5
-    |  lus TMP1, 0xfffe
-    |  ori TMP1, TMP1, 0x7fff
+    |  lus TMP1, (LJ_KEYINDEX >> 16)
+    |  ori TMP1, TMP1, (LJ_KEYINDEX & 0xffff)
     |  stw ZERO, WORD_LO-8(RA)          // Initialize control var.
     |  stw TMP1, WORD_HI-8(RA)
     |    addis PC, TMP3, -(BCBIAS_J*4 >> 16)


### PR DESCRIPTION
Hello,

I belong to the IBM Power porting team. We are working on aligning code as per other architectures. Hence done few code changes in next_1 function and relevant code changes in other parts. Earlier we had raised https://github.com/openresty/luajit2/pull/212 PR. This PR has few more further changes.

All the tests are successful on ppc64le.

<built-in>: note: this is the location of the previous definition
=== test/unportable/math_special.lua
=== test/ffi/ffi_redir.lua
=== test/ffi/ffi_call.lua
=== test/ffi/unsink_64_kptr.lua
=== test/ffi/ffi_istype.lua
=== test/ffi/ffi_new.lua
=== test/ffi/ffi_tabov.lua
=== test/ffi/ffi_jit_arith.lua
=== test/ffi/ffi_lex_number.lua
=== test/ffi/ffi_copy_fill.lua
=== test/ffi/ffi_type_punning.lua
=== test/ffi/ffi_enum.lua
=== test/ffi/ffi_const.lua
=== test/ffi/ffi_parse_struct.lua
=== test/ffi/ffi_arith_ptr.lua
=== test/ffi/ffi_jit_misc.lua
=== test/ffi/ffi_bitfield.lua
=== test/ffi/ffi_meta_tostring.lua
=== test/ffi/ffi_bit64.lua
=== test/ffi/ffi_sink.lua
=== test/ffi/ffi_parse_array.lua
=== test/ffi/ffi_convert.lua
=== test/ffi/ffi_jit_struct.lua
=== test/ffi/ffi_metatype.lua
=== test/ffi/ffi_jit_complex.lua
=== test/ffi/ffi_callback.lua
=== test/ffi/ffi_parse_basic.lua
=== test/ffi/ffi_gcstep_recursive.lua
=== test/ffi/ffi_jit_conv.lua
=== test/ffi/ffi_parse_cdef.lua
=== test/ffi/ffi_jit_call.lua
=== test/ffi/ffi_jit_array.lua
=== test/ffi/ffi_err.lua
=== test/ffi/ffi_nosink.lua
=== test/misc/string_sub_opt.lua
=== test/misc/sink_nosink.lua
=== test/misc/meta_comp_jit.lua
=== test/misc/string_sub.lua
=== test/misc/multi_result_call_next.lua
=== test/misc/argcheck.lua
=== test/misc/phi_rot18.lua
=== test/misc/string_char.lua
=== test/misc/table_chain_bug_LuaJIT_494.lua
=== test/misc/tcall_loop.lua
=== test/misc/hook_norecord.lua
=== test/misc/stackovc.lua
=== test/misc/nsieve.lua
Primes up to        1        0
=== test/misc/jit_flush.lua
=== test/misc/jloop-itern-stack-check-fix.lua
=== test/misc/fwd_upval.lua
=== test/misc/meta_getset.lua
=== test/misc/hook_active.lua
=== test/misc/exit_frame.lua
=== test/misc/kfold.lua
=== test/misc/hook_top.lua
=== test/misc/parse_andor.lua
=== test/misc/meta_tset_nilget.lua
=== test/misc/recsump.lua
=== test/misc/phi_rot8.lua
=== test/misc/exit_jfuncf.lua
=== test/misc/compare.lua
=== test/misc/snap_gcexit.lua
=== test/misc/meta_tset_resize.lua
=== test/misc/iter.lua
=== test/misc/unordered.lua
=== test/misc/meta_nomm.lua
=== test/misc/stitch.lua
=== test/misc/pcall_jit.lua
=== test/misc/xpcall_jit.lua
=== test/misc/hstore_elimination.lua
=== test/misc/phi_rotx.lua
=== test/misc/assign_tset_tmp.lua
=== test/misc/sort.lua
=== test/misc/string_op.lua
=== test/misc/math_random.lua
=== test/misc/meta_eq_jit.lua
=== test/misc/meta_arith.lua
=== test/misc/snap_top.lua
=== test/misc/iter-bug.lua
=== test/misc/ack_notail.lua
Ack(3,1): 13
=== test/misc/api_call.lua
=== test/misc/coro_traceback.lua
=== test/misc/string_dump.lua
=== test/misc/tlen_loop.lua
=== test/misc/lightud.lua
=== test/misc/goto.lua
=== test/misc/dse_field.lua
=== test/misc/fori_coerce.lua
=== test/misc/meta_framegap.lua
=== test/misc/meta_call.lua
=== test/misc/cat_jit.lua
=== test/misc/tonumber_tostring.lua
=== test/misc/parse_hex.lua
=== test/misc/catch_wrap.lua
=== test/misc/parse_esc.lua
=== test/misc/stack_gc.lua
=== test/misc/tnew_tdup.lua
=== test/misc/meta_tget.lua
=== test/misc/table_alias.lua
=== test/misc/fwd_tnew_tdup.lua
=== test/misc/constov.lua
=== test/misc/uclo.lua
=== test/misc/coro_yield.lua
=== test/misc/hook_record.lua
=== test/misc/assign_tset_prevnil.lua
=== test/misc/fwd_hrefk_rollback.lua
=== test/misc/gc_trace.lua
=== test/misc/parse_misc.lua
=== test/misc/string_byte.lua
=== test/misc/meta_len.lua
=== test/misc/meta_arith_jit.lua
=== test/misc/wbarrier_jit.lua
=== test/misc/sink_alloc.lua
=== test/misc/fac.lua
1
=== test/misc/gc_rechain.lua
=== test/misc/dse_array.lua
=== test/misc/bit_op.lua
=== test/misc/table_remove.lua
=== test/misc/unordered_jit.lua
=== test/misc/phi_rot9.lua
=== test/misc/select.lua
=== test/misc/meta_tget_nontab.lua
=== test/misc/phi_copyspill.lua
=== test/misc/snap_top2.lua
=== test/misc/phi_conv.lua
=== test/misc/debug_meta.lua
=== test/misc/table_insert.lua
=== test/misc/exit_growstack.lua
=== test/misc/recsum.lua
=== test/misc/fuse.lua
=== test/misc/wbarrier.lua
=== test/misc/jit_record.lua
10
63
=== test/misc/libfuncs.lua
=== test/misc/fastfib.lua
Fib(1): 1
=== test/misc/fib.lua
Fib(1): 1
=== test/misc/hook_line.lua
=== test/misc/recurse_tail.lua
=== test/misc/gcstep.lua
=== test/misc/wbarrier_obar.lua
=== test/misc/table_misc.lua
=== test/misc/meta_comp.lua
=== test/misc/tcall_base.lua
=== test/misc/alias_alloc.lua
=== test/misc/modulo.lua
=== test/misc/getfenv.lua
=== test/misc/phi_ref.lua
=== test/misc/tonumber_scan.lua
=== test/misc/stackov.lua
=== test/misc/strcmp.lua
=== test/misc/ack.lua
Ack(3,1): 13
=== test/misc/meta_tset_str.lua
=== test/misc/stack_purge.lua
=== test/misc/for_dir.lua
=== test/misc/recurse_deep.lua
=== test/misc/parse_comp.lua
=== test/misc/meta_cat.lua
=== test/misc/debug_gc.lua
=== test/misc/meta_tset.lua
=== test/misc/meta_eq.lua
=== test/misc/pairs_bug.lua
=== test/misc/self.lua
=== test/misc/tak.lua
2
=== test/misc/dualnum.lua
=== test/misc/loop_unroll.lua
=== test/misc/vararg_jit.lua
=== test/misc/meta_pairs.lua
All tests successful.
+ '[' 0 -ne 0 ']'
+ set +ex
Build and tests Successful!
 