### PR TITLE
s390x: simplify ceil/floor code

### DIFF
--- a/src/vm_s390x.dasc
+++ b/src/vm_s390x.dasc
@@ -2126,16 +2126,8 @@ static void build_subroutines(BuildCtx *ctx)
   |// Value to round is in f0. May clobber f0-f7 and r0. Return address is r14.
   |.macro vm_round, name, mask
   |->name:
-  |  ldr f4, f0
-  |  lghi r0, 1
-  |  cdfbr f1, r0
-  |  didbr f0, f2, f1, mask // f0=remainder, f2=quotient.
-  |  fidbra f4, mask, f4, 0
-  |  ldr f0, f4
-  |  jnle >1
+  |  fidbra f0, mask, f0, 0
   |  br r14
-  |1: // partial remainder (sanity check)
-  |  stg r0, 0
   |.endmacro
   |
   |  vm_round vm_floor, 7 // Round towards -inf.


### PR DESCRIPTION
The previous change[1] to this code left quite a bit of dead code behind, when it switched vm_round from using DIDBR (divide to integer) to FIDBR (load floating-point integer). Simplify the code by removing the remains of the previous implementation.

As a side effect, math.ceil() etc. now execute without crashing in QEMU, which was previously not the case because QEMU doesn't implement DIDBR.

[1]: https://github.com/openresty/luajit2/pull/177