### PR TITLE
Fix BC_UNM of 0 on s390x

### DIFF
--- a/src/vm_s390x.dasc
+++ b/src/vm_s390x.dasc
@@ -2614,15 +2614,18 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  sllg RA, RA, 3
     |  sllg RD, RD, 3
     |  lg RB, 0(RD, BASE)
-    |  checkint RB, >3
-    |  lcr RB, RB; jo >2
+    |  checkint RB, >4
+    |  lcr RB, RB; je >2; jo >3
     |1:
     |  stg RB, 0(RA, BASE)
     |  ins_next
     |2:
-    |  llihh RB, 0x41e0 // (double)2^31
+    |  llihh RB, 0x8000 // (double)-0
     |  j <1
     |3:
+    |  llihh RB, 0x41e0 // (double)2^31
+    |  j <1
+    |4:
     |  jh ->vmeta_unm
     |  // Toggle sign bit.
     |  llihh TMPR0, 0x8000


### PR DESCRIPTION
Negation of 0 is -0, but currently BC_UNM produces 0. This is because 0 is stored as an integer (LJ_TISNUM) and handled using LOAD COMPLEMENT instruction, which operates on integers and thus has no concept of -0.

Fix by special-casing 0, like it's already done in the other JITs.