### PR TITLE
s390x: Fix errcode return during exception unwinding

### DIFF
--- a/src/lj_arch.h
+++ b/src/lj_arch.h
@@ -498,7 +498,9 @@
 #define LJ_ARCH_BITS		64
 #define LJ_ARCH_ENDIAN		LUAJIT_BE
 #define LJ_TARGET_S390X		1
-#define LJ_TARGET_EHRETREG	0xe
+/* On s390x, _Unwind_SetGR can only be used with call-saved registers.
+   Use %r7 as EH return register; value will be moved into %r2 by the handler.  */
+#define LJ_TARGET_EHRETREG	7
 #define LJ_TARGET_JUMPRANGE	32	/* +-2^32 = +-4GB (32-bit, halfword aligned) */
 #define LJ_TARGET_MASKSHIFT	1
 #define LJ_TARGET_MASKROT	1

--- a/src/vm_s390x.dasc
+++ b/src/vm_s390x.dasc
@@ -407,14 +407,15 @@ static void build_subroutines(BuildCtx *ctx)
   |  j <3
   |
   |->vm_unwind_yield:
-  |  lghi CRET1, LUA_YIELD
+  |  lghi RB, LUA_YIELD
   |  j ->vm_unwind_c_eh
   |
   |->vm_unwind_c:			// Unwind C stack, return from vm_pcall.
   |  // (void *cframe, int errcode)
   |  lgr sp, CARG1
-  |  lgfr CARG2, CRET1			// Error return status for vm_pcall.
+  |  lgfr RB, CARG2			// Error return status for vm_pcall.
   |->vm_unwind_c_eh:			// Landing pad for external unwinder.
+  |  lgr CRET1, RB			// Move return status into ABI reg.
   |  lg L:RB, SAVE_L
   |  lg GL:RB, L:RB->glref
   |  lghi TMPR1, ~LJ_VMST_C


### PR DESCRIPTION
LJ_TARGET_EHRETREG was incorrectly set to 14, which is the return *address* register.  The error return value instead needs to be installed into register 2.  This cannot be done directly with _Unwind_SetGR, as this only supports callee- saved registers on s390x.

Instead, use _Unwind_SetGR to install the return value into register 7 and move it from there into register 2 in the vm_unwind_c_eh handler.