### PR TITLE
s390x: Fix big-endian access to ERRF cframe slot

### DIFF
--- a/src/vm_s390x.dasc
+++ b/src/vm_s390x.dasc
@@ -70,7 +70,7 @@
 |.define SAVE_GPRS_P,	48(sp)  // Save area for r6-r15 (10*8 bytes) in prologue (before stack frame is allocated).
 |
 |// Argument save area.
-|.define SAVE_ERRF,	280(sp) // Argument 4, in r5.
+|.define SAVE_ERRF,	280(sp) // Argument 4, in r5. Size is 4-bytes.
 |.define SAVE_NRES,	272(sp)	// Argument 3, in r4. Size is 4-bytes.
 |.define SAVE_CFRAME,	264(sp)	// Argument 2, in r3.
 |.define SAVE_L,	256(sp)	// Argument 1, in r2.
@@ -495,7 +495,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  stg RD, SAVE_PC			// Any value outside of bytecode is ok.
   |  stg RD, SAVE_CFRAME
   |  st RD, SAVE_NRES
-  |  stg RD, SAVE_ERRF
+  |  st RD, SAVE_ERRF
   |  stg KBASE, L:RB->cframe
   |  clm RD, 1, L:RB->status
   |  je >2				// Initial resume (like a call).
@@ -520,8 +520,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  // (lua_State *L, TValue *base, int nres1, ptrdiff_t ef)
   |  saveregs
   |  lghi PC, FRAME_CP
-  |  llgfr CARG4, CARG4
-  |  stg CARG4, SAVE_ERRF
+  |  st CARG4, SAVE_ERRF
   |  j >1
   |
   |->vm_call:				// Setup C frame and enter VM.
@@ -574,7 +573,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  sg KBASE, L:RB->top
   |   lg DISPATCH, L:RB->glref	// Setup pointer to dispatch table.
   |  lghi TMPR0, 0
-  |  stg TMPR0, SAVE_ERRF		// No error function.
+  |  st TMPR0, SAVE_ERRF		// No error function.
   |  st KBASE, SAVE_NRES		// Neg. delta means cframe w/o frame.
   |   aghi DISPATCH, GG_G2DISP
   |  // Handler may change cframe_nres(L->cframe) or cframe_errfunc(L->cframe).


### PR DESCRIPTION
The ERRF slot is currently stored as an 8-byte value by vm_s390x.dasc code, but it is accessed as 4-byte value by common code via the cframe_errfunc macro in lj_frame.h.

On the big-endian s390x platform this macro will therefore always return 0, causing error function invocations to be skipped.

Fixed by storing the ERRF slot as 4-byte value as well.