### PR TITLE
PPC soft-float: fix ipairs() returning corrupted values and pairs() yielding a spurious nil

### DIFF
--- a/src/vm_ppc.dasc
+++ b/src/vm_ppc.dasc
@@ -5803,6 +5803,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  lwz RB, WORD_HI(TMP3)
     |.else
     |  add CARG3, TMP2, TMP3
+    |  lwz RB, WORD_HI(CARG3)
     |  lwz CARG1, 0(CARG3)
     |  lwz CARG2, 4(CARG3)
     |   add NODE:TMP3, TMP2, TMP3

--- a/src/vm_ppc.dasc
+++ b/src/vm_ppc.dasc
@@ -1833,7 +1833,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  lwz TMP2, WORD_HI(TMP1)
   |.else
   |  lwzux TMP2, TMP1, TMP3
-  |  lwz TMP3, WORD_HI(TMP1)
+  |  lwz TMP3, 4(TMP1)
   |.endif
   |1:
   |  checknil TMP2


### PR DESCRIPTION
Two independent bugs in `src/vm_ppc.dasc`, both confined to the `.if not FPU` branch and both introduced by 2763a421 ("Patch for PPC64 support"). Upstream LuaJIT is not affected — on the same board, the distro's upstream LuaJIT returns the correct results.

Reproducers on Turris 1.x (e500v2, 32-bit big-endian, musl, soft-float):

```lua
local sum = 0
for _, v in ipairs({10, 20, 30}) do
    sum = sum + v
end
assert(sum == 60)
```

```lua
local expected = {7, 8, 9}
local i = 0
for k, v in pairs(expected) do
    i = i + 1
    assert(k == i and v == expected[i])
end
assert(i == 3)
```

Before the fixes, the `ipairs()` test yields `-42` instead of `60` and the `pairs()` test sees an extra `(nil, nil)` iteration. With the fixes, both pass, with and without the JIT.

`ipairs()` also has a memory-safety angle: only the payload half of the TValue is wrong while the itype stays correct, so for GC-typed elements the type tag ends up in the GCref and `tostring()` dereferences a fabricated pointer.

Verified on hardware, and through the OpenWrt package build in openwrt/packages#30280, where the resulting `powerpc_8548` package was installed on the device and behaves correctly.
