### PR TITLE
PPC64: use pointer-width accesses when resetting string buffer

### DIFF
--- a/src/vm_ppc.dasc
+++ b/src/vm_ppc.dasc
@@ -2700,11 +2700,11 @@ static void build_subroutines(BuildCtx *ctx)
   |  checkstr CARG3
   |   la SBUF:CARG1, DISPATCH_GL(tmpbuf)(DISPATCH)
   |  bne ->fff_fallback
-  |   lwz TMP0, SBUF:CARG1->b
+  |   lp TMP0, SBUF:CARG1->b
   |  stw L, SBUF:CARG1->L
   |  stp BASE, L->base
   |  stw PC, SAVE_PC
-  |   stw TMP0, SBUF:CARG1->w
+  |   stp TMP0, SBUF:CARG1->w
   |  bl extern lj_buf_putstr_ .. name
   |  bl extern lj_buf_tostr
   |  b ->fff_resstr


### PR DESCRIPTION
The PPC string lower/upper/reverse fast-function wrapper resets SBuf::w from SBuf::b using lwz/stw. Both fields are char pointers, so these 32-bit accesses are incorrect on PPC64.

This breaks the reset on big-endian PPC64, causing string.lower(), string.upper(), and string.reverse() to append to stale temporary buffer contents.

Use lp/stp so the accesses have the target pointer width.